### PR TITLE
os.path.dirname returns an empty path

### DIFF
--- a/autopwn.py
+++ b/autopwn.py
@@ -521,7 +521,7 @@ class Configuration:
    def __init__(self, args):
       index = 0
       target_file = args.argument['file']
-      pathname = os.path.dirname(sys.argv[0])
+      pathname = os.path.dirname(os.path.abspath(sys.argv[0]))
       tools_directory = os.path.abspath(pathname) + "/tools/"
 
       # Command line parallel option 


### PR DESCRIPTION
This happens because os.path.dirname only splits the passed filename into components without taking into account the current directory. As a result, it looks for autopwn.apc in "/". Modified the code to return the path of the current directory.
